### PR TITLE
ISPN-7468 Added Spring Cache automatic discovery

### DIFF
--- a/inifinispan-spring-boot-starter-autoconfigure/pom.xml
+++ b/inifinispan-spring-boot-starter-autoconfigure/pom.xml
@@ -4,11 +4,11 @@
 
     <parent>
         <groupId>org.infinispan</groupId>
-        <artifactId>inifinispan-spring-boot-starter-parent</artifactId>
+        <artifactId>infinispan-spring-boot-starter-parent</artifactId>
         <version>1.0.0.Beta1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>inifinispan-spring-boot-starter-autoconfigure</artifactId>
+    <artifactId>infinispan-spring-boot-starter-autoconfigure</artifactId>
 
     <dependencies>
         <dependency>

--- a/inifinispan-spring-boot-starter-autoconfigure/pom.xml
+++ b/inifinispan-spring-boot-starter-autoconfigure/pom.xml
@@ -31,5 +31,15 @@
             <artifactId>infinispan-client-hotrod</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-spring4-embedded</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-spring4-remote</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 </project>

--- a/inifinispan-spring-boot-starter-autoconfigure/src/main/java/infinispan/autoconfigure/embedded/InfinispanEmbeddedAutoConfiguration.java
+++ b/inifinispan-spring-boot-starter-autoconfigure/src/main/java/infinispan/autoconfigure/embedded/InfinispanEmbeddedAutoConfiguration.java
@@ -10,7 +10,6 @@ import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -21,45 +20,48 @@ import infinispan.autoconfigure.common.InfinispanProperties;
 
 @Configuration
 @ComponentScan
-@ConditionalOnClass(EmbeddedCacheManager.class)
+//Since a jar with configuration might be missing (which would result in TypeNotPresentExceptionProxy), we need to
+//use String based methods.
+//See https://github.com/spring-projects/spring-boot/issues/1733
+@ConditionalOnClass(name = "org.infinispan.manager.EmbeddedCacheManager")
 @ConditionalOnProperty(value = "infinispan.embedded.enabled", havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties(InfinispanProperties.class)
 public class InfinispanEmbeddedAutoConfiguration {
 
-    public static final String DEFAULT_JMX_DOMAIN = "infinispan";
+   public static final String DEFAULT_JMX_DOMAIN = "infinispan";
 
-    @Autowired
-    private InfinispanProperties infinispanProperties;
+   @Autowired
+   private InfinispanProperties infinispanProperties;
 
-    @Autowired(required = false)
-    private List<InfinispanCacheConfigurer> configurers = Collections.emptyList();
+   @Autowired(required = false)
+   private List<InfinispanCacheConfigurer> configurers = Collections.emptyList();
 
-    @Autowired(required = false)
-    private InfinispanGlobalConfigurer infinispanGlobalConfigurer;
+   @Autowired(required = false)
+   private InfinispanGlobalConfigurer infinispanGlobalConfigurer;
 
-    @Bean(destroyMethod = "stop")
-    public DefaultCacheManager defaultCacheManager() throws IOException {
-        final String configXml = infinispanProperties.getEmbedded().getConfigXml();
-        final GlobalConfiguration defaultGlobalConfiguration =
-                new GlobalConfigurationBuilder()
-                    .globalJmxStatistics().jmxDomain(DEFAULT_JMX_DOMAIN).enable()
-                    .transport().clusterName(infinispanProperties.getEmbedded().getClusterName())
-                    .build();
+   @Bean(destroyMethod = "stop")
+   public DefaultCacheManager defaultCacheManager() throws IOException {
+      final String configXml = infinispanProperties.getEmbedded().getConfigXml();
+      final GlobalConfiguration defaultGlobalConfiguration =
+            new GlobalConfigurationBuilder()
+                  .globalJmxStatistics().jmxDomain(DEFAULT_JMX_DOMAIN).enable()
+                  .transport().clusterName(infinispanProperties.getEmbedded().getClusterName())
+                  .build();
 
-        final GlobalConfiguration globalConfiguration =
-            infinispanGlobalConfigurer == null? defaultGlobalConfiguration
-                                              : infinispanGlobalConfigurer.getGlobalConfiguration();
+      final GlobalConfiguration globalConfiguration =
+            infinispanGlobalConfigurer == null ? defaultGlobalConfiguration
+                  : infinispanGlobalConfigurer.getGlobalConfiguration();
 
-        final DefaultCacheManager manager =
-                configXml.isEmpty()? new DefaultCacheManager(globalConfiguration)
-                                   : new DefaultCacheManager(configXml);
+      final DefaultCacheManager manager =
+            configXml.isEmpty() ? new DefaultCacheManager(globalConfiguration)
+                  : new DefaultCacheManager(configXml);
 
-        configureCaches(manager);
+      configureCaches(manager);
 
-        return manager;
-    }
+      return manager;
+   }
 
-    private void configureCaches(final EmbeddedCacheManager manager) {
-        configurers.forEach(configurer -> configurer.configureCache(manager));
-    }
+   private void configureCaches(final EmbeddedCacheManager manager) {
+      configurers.forEach(configurer -> configurer.configureCache(manager));
+   }
 }

--- a/inifinispan-spring-boot-starter-autoconfigure/src/main/java/infinispan/autoconfigure/embedded/InfinispanEmbeddedCacheManagerAutoConfiguration.java
+++ b/inifinispan-spring-boot-starter-autoconfigure/src/main/java/infinispan/autoconfigure/embedded/InfinispanEmbeddedCacheManagerAutoConfiguration.java
@@ -1,0 +1,28 @@
+package infinispan.autoconfigure.embedded;
+
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.spring.provider.SpringEmbeddedCacheManager;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan
+//Since a jar with configuration might be missing (which would result in TypeNotPresentExceptionProxy), we need to
+//use String based methods.
+//See https://github.com/spring-projects/spring-boot/issues/1733
+@ConditionalOnClass(name = "org.infinispan.spring.provider.SpringEmbeddedCacheManager")
+@ConditionalOnMissingBean(type = {"org.infinispan.spring.provider.SpringEmbeddedCacheManager", "org.infinispan.spring.provider.SpringEmbeddedCacheManagerFactoryBean"})
+@ConditionalOnBean(type = "org.infinispan.manager.EmbeddedCacheManager")
+@ConditionalOnProperty(value = "infinispan.embedded.cache.enabled", havingValue = "true", matchIfMissing = true)
+public class InfinispanEmbeddedCacheManagerAutoConfiguration {
+
+   @Bean
+   public SpringEmbeddedCacheManager springEmbeddedCacheManager(EmbeddedCacheManager embeddedCacheManager) {
+      return new SpringEmbeddedCacheManager(embeddedCacheManager);
+   }
+}

--- a/inifinispan-spring-boot-starter-autoconfigure/src/main/java/infinispan/autoconfigure/remote/InfinispanRemoteAutoConfiguration.java
+++ b/inifinispan-spring-boot-starter-autoconfigure/src/main/java/infinispan/autoconfigure/remote/InfinispanRemoteAutoConfiguration.java
@@ -6,7 +6,6 @@ import java.util.Properties;
 
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
-import org.infinispan.manager.EmbeddedCacheManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -22,7 +21,10 @@ import infinispan.autoconfigure.common.InfinispanProperties;
 
 @Configuration
 @ComponentScan
-@ConditionalOnClass(RemoteCacheManager.class)
+//Since a jar with configuration might be missing (which would result in TypeNotPresentExceptionProxy), we need to
+//use String based methods.
+//See https://github.com/spring-projects/spring-boot/issues/1733
+@ConditionalOnClass(name = "org.infinispan.client.hotrod.RemoteCacheManager")
 @Conditional(InfinispanRemoteFileChecker.class)
 @ConditionalOnProperty(value = "infinispan.remote.enabled", havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties(InfinispanProperties.class)
@@ -41,7 +43,7 @@ public class InfinispanRemoteAutoConfiguration {
    @Conditional(InfinispanRemoteFileChecker.class)
    public RemoteCacheManager remoteCacheManager() throws IOException {
       org.infinispan.client.hotrod.configuration.Configuration configuration;
-      if(infinispanRemoteConfigurer != null) {
+      if (infinispanRemoteConfigurer != null) {
          configuration = infinispanRemoteConfigurer.getRemoteConfiguration();
       } else {
          final String remoteClientPropertiesLocation = infinispanProperties.getRemote().getClientProperties();

--- a/inifinispan-spring-boot-starter-autoconfigure/src/main/java/infinispan/autoconfigure/remote/InfinispanRemoteCacheManagerAutoConfiguration.java
+++ b/inifinispan-spring-boot-starter-autoconfigure/src/main/java/infinispan/autoconfigure/remote/InfinispanRemoteCacheManagerAutoConfiguration.java
@@ -1,0 +1,28 @@
+package infinispan.autoconfigure.remote;
+
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.spring.provider.SpringRemoteCacheManager;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan
+//Since a jar with configuration might be missing (which would result in TypeNotPresentExceptionProxy), we need to
+//use String based methods.
+//See https://github.com/spring-projects/spring-boot/issues/1733
+@ConditionalOnClass(name = "org.infinispan.spring.provider.SpringRemoteCacheManager")
+@ConditionalOnMissingBean(type = {"org.infinispan.spring.provider.SpringRemoteCacheManager", "org.infinispan.spring.provider.SpringRemoteCacheManagerFactoryBean"})
+@ConditionalOnBean(type = "org.infinispan.client.hotrod.RemoteCacheManager")
+@ConditionalOnProperty(value = "infinispan.remote.cache.enabled", havingValue = "true", matchIfMissing = true)
+public class InfinispanRemoteCacheManagerAutoConfiguration {
+
+   @Bean
+   public SpringRemoteCacheManager springRemoteCacheManager(RemoteCacheManager remoteCacheManager) {
+      return new SpringRemoteCacheManager(remoteCacheManager);
+   }
+}

--- a/inifinispan-spring-boot-starter-test-embedded/pom.xml
+++ b/inifinispan-spring-boot-starter-test-embedded/pom.xml
@@ -4,16 +4,16 @@
 
     <parent>
         <groupId>org.infinispan</groupId>
-        <artifactId>inifinispan-spring-boot-starter-parent</artifactId>
+        <artifactId>infinispan-spring-boot-starter-parent</artifactId>
         <version>1.0.0.Beta1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>inifinispan-spring-boot-starter-test-embedded</artifactId>
+    <artifactId>infinispan-spring-boot-starter-test-embedded</artifactId>
 
     <dependencies>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>inifinispan-spring-boot-starter</artifactId>
+            <artifactId>infinispan-spring-boot-starter</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/inifinispan-spring-boot-starter-test-embedded/pom.xml
+++ b/inifinispan-spring-boot-starter-test-embedded/pom.xml
@@ -23,6 +23,11 @@
             <artifactId>infinispan-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-spring4-embedded</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/inifinispan-spring-boot-starter-test-embedded/src/test/java/test/infinispan/autoconfigure/embedded/InfinispanEmbeddedAutoConfigurationIntegrationConfigurerTest.java
+++ b/inifinispan-spring-boot-starter-test-embedded/src/test/java/test/infinispan/autoconfigure/embedded/InfinispanEmbeddedAutoConfigurationIntegrationConfigurerTest.java
@@ -15,38 +15,39 @@ import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import infinispan.autoconfigure.embedded.InfinispanEmbeddedAutoConfiguration;
+import infinispan.autoconfigure.embedded.InfinispanEmbeddedCacheManagerAutoConfiguration;
 import test.infinispan.autoconfigure.testconfiguration.InfinispanCacheTestConfiguration;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = { InfinispanEmbeddedAutoConfiguration.class
-                                          , InfinispanCacheTestConfiguration.class })
+@SpringApplicationConfiguration(classes = {InfinispanEmbeddedAutoConfiguration.class, InfinispanEmbeddedCacheManagerAutoConfiguration.class
+      , InfinispanCacheTestConfiguration.class})
 public class InfinispanEmbeddedAutoConfigurationIntegrationConfigurerTest {
 
-    @Autowired
-    EmbeddedCacheManager defaultCacheManager;
+   @Autowired
+   EmbeddedCacheManager defaultCacheManager;
 
-    @Test
-    public void contextLoads() {
+   @Test
+   public void contextLoads() {
 
-    }
+   }
 
-    @Test
-    public void testWithCacheConfigurer() {
-        assertThat(defaultCacheManager.getCacheNames()).isEqualTo(
-                Collections.singleton(InfinispanCacheTestConfiguration.TEST_CACHE_NAME));
+   @Test
+   public void testWithCacheConfigurer() {
+      assertThat(defaultCacheManager.getCacheNames()).isEqualTo(
+            Collections.singleton(InfinispanCacheTestConfiguration.TEST_CACHE_NAME));
 
-        final Configuration testCacheConfiguration = defaultCacheManager.getCacheConfiguration(InfinispanCacheTestConfiguration.TEST_CACHE_NAME);
-        assertThat(testCacheConfiguration.jmxStatistics().enabled()).isTrue();
-        assertThat(testCacheConfiguration.eviction().size()).isEqualTo(1000L);
-        assertThat(testCacheConfiguration.eviction().strategy()).isEqualTo(EvictionStrategy.LRU);
-    }
+      final Configuration testCacheConfiguration = defaultCacheManager.getCacheConfiguration(InfinispanCacheTestConfiguration.TEST_CACHE_NAME);
+      assertThat(testCacheConfiguration.jmxStatistics().enabled()).isTrue();
+      assertThat(testCacheConfiguration.eviction().size()).isEqualTo(1000L);
+      assertThat(testCacheConfiguration.eviction().strategy()).isEqualTo(EvictionStrategy.LRU);
+   }
 
-    @Test
-    public void testWithGlobalConfigurer() {
-        final GlobalConfiguration globalConfiguration = defaultCacheManager.getCacheManagerConfiguration();
+   @Test
+   public void testWithGlobalConfigurer() {
+      final GlobalConfiguration globalConfiguration = defaultCacheManager.getCacheManagerConfiguration();
 
-        assertThat(globalConfiguration.globalJmxStatistics().enabled()).isTrue();
-        assertThat(globalConfiguration.globalJmxStatistics().domain()).isEqualTo(InfinispanCacheTestConfiguration.TEST_GLOBAL_JMX_DOMAIN);
-        assertThat(globalConfiguration.transport().clusterName()).isEqualTo(InfinispanCacheTestConfiguration.TEST_CLUSTER);
-    }
+      assertThat(globalConfiguration.globalJmxStatistics().enabled()).isTrue();
+      assertThat(globalConfiguration.globalJmxStatistics().domain()).isEqualTo(InfinispanCacheTestConfiguration.TEST_GLOBAL_JMX_DOMAIN);
+      assertThat(globalConfiguration.transport().clusterName()).isEqualTo(InfinispanCacheTestConfiguration.TEST_CLUSTER);
+   }
 }

--- a/inifinispan-spring-boot-starter-test-embedded/src/test/java/test/infinispan/autoconfigure/embedded/InfinispanEmbeddedAutoConfigurationIntegrationConfigurerTest.java
+++ b/inifinispan-spring-boot-starter-test-embedded/src/test/java/test/infinispan/autoconfigure/embedded/InfinispanEmbeddedAutoConfigurationIntegrationConfigurerTest.java
@@ -11,7 +11,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import infinispan.autoconfigure.embedded.InfinispanEmbeddedAutoConfiguration;
@@ -19,7 +19,7 @@ import infinispan.autoconfigure.embedded.InfinispanEmbeddedCacheManagerAutoConfi
 import test.infinispan.autoconfigure.testconfiguration.InfinispanCacheTestConfiguration;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = {InfinispanEmbeddedAutoConfiguration.class, InfinispanEmbeddedCacheManagerAutoConfiguration.class
+@SpringBootTest(classes = {InfinispanEmbeddedAutoConfiguration.class, InfinispanEmbeddedCacheManagerAutoConfiguration.class
       , InfinispanCacheTestConfiguration.class})
 public class InfinispanEmbeddedAutoConfigurationIntegrationConfigurerTest {
 

--- a/inifinispan-spring-boot-starter-test-embedded/src/test/java/test/infinispan/autoconfigure/embedded/InfinispanEmbeddedAutoConfigurationIntegrationTest.java
+++ b/inifinispan-spring-boot-starter-test-embedded/src/test/java/test/infinispan/autoconfigure/embedded/InfinispanEmbeddedAutoConfigurationIntegrationTest.java
@@ -10,47 +10,47 @@ import org.infinispan.spring.provider.SpringEmbeddedCacheManager;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import infinispan.autoconfigure.embedded.InfinispanEmbeddedAutoConfiguration;
 import infinispan.autoconfigure.embedded.InfinispanEmbeddedCacheManagerAutoConfiguration;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration({InfinispanEmbeddedAutoConfiguration.class, InfinispanEmbeddedCacheManagerAutoConfiguration.class})
+@SpringBootTest(classes = {InfinispanEmbeddedAutoConfiguration.class, InfinispanEmbeddedCacheManagerAutoConfiguration.class})
 public class InfinispanEmbeddedAutoConfigurationIntegrationTest {
 
-    @Autowired
-    EmbeddedCacheManager defaultCacheManager;
+   @Autowired
+   EmbeddedCacheManager defaultCacheManager;
 
-    @Autowired
-    SpringEmbeddedCacheManager springEmbeddedCacheManager;
+   @Autowired
+   SpringEmbeddedCacheManager springEmbeddedCacheManager;
 
-    @Test
-    public void contextLoads() {
+   @Test
+   public void contextLoads() {
 
-    }
+   }
 
-    @Test
-    public void testAutowired() {
-        assertThat(defaultCacheManager).isNotNull();
-    }
+   @Test
+   public void testAutowired() {
+      assertThat(defaultCacheManager).isNotNull();
+   }
 
-    @Test
-    public void testDefaultConfigurations() {
-        assertThat(defaultCacheManager.getClusterName()).isEqualTo("default-autoconfigure");
-        assertThat(defaultCacheManager.getCacheNames()).isEmpty();
+   @Test
+   public void testDefaultConfigurations() {
+      assertThat(defaultCacheManager.getClusterName()).isEqualTo("default-autoconfigure");
+      assertThat(defaultCacheManager.getCacheNames()).isEmpty();
 
-        final Configuration defaultCacheConfiguration = defaultCacheManager.getDefaultCacheConfiguration();
-        assertThat(defaultCacheConfiguration.jmxStatistics().enabled()).isFalse();
+      final Configuration defaultCacheConfiguration = defaultCacheManager.getDefaultCacheConfiguration();
+      assertThat(defaultCacheConfiguration.jmxStatistics().enabled()).isFalse();
 
-        final GlobalConfiguration globalConfiguration = defaultCacheManager.getCacheManagerConfiguration();
-        assertThat(globalConfiguration.globalJmxStatistics().enabled()).isTrue();
-        assertThat(globalConfiguration.globalJmxStatistics().domain()).isEqualTo(DEFAULT_JMX_DOMAIN);
-    }
+      final GlobalConfiguration globalConfiguration = defaultCacheManager.getCacheManagerConfiguration();
+      assertThat(globalConfiguration.globalJmxStatistics().enabled()).isTrue();
+      assertThat(globalConfiguration.globalJmxStatistics().domain()).isEqualTo(DEFAULT_JMX_DOMAIN);
+   }
 
-    @Test
-    public void testIfSpringCachingWasCreatedUsingProperEmbeddedCacheManager() throws Exception {
-        assertThat(defaultCacheManager).isEqualTo(springEmbeddedCacheManager.getNativeCacheManager());
-    }
+   @Test
+   public void testIfSpringCachingWasCreatedUsingProperEmbeddedCacheManager() throws Exception {
+      assertThat(defaultCacheManager).isEqualTo(springEmbeddedCacheManager.getNativeCacheManager());
+   }
 }

--- a/inifinispan-spring-boot-starter-test-embedded/src/test/java/test/infinispan/autoconfigure/embedded/InfinispanEmbeddedAutoConfigurationIntegrationTest.java
+++ b/inifinispan-spring-boot-starter-test-embedded/src/test/java/test/infinispan/autoconfigure/embedded/InfinispanEmbeddedAutoConfigurationIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.spring.provider.SpringEmbeddedCacheManager;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,13 +14,17 @@ import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import infinispan.autoconfigure.embedded.InfinispanEmbeddedAutoConfiguration;
+import infinispan.autoconfigure.embedded.InfinispanEmbeddedCacheManagerAutoConfiguration;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(InfinispanEmbeddedAutoConfiguration.class)
+@SpringApplicationConfiguration({InfinispanEmbeddedAutoConfiguration.class, InfinispanEmbeddedCacheManagerAutoConfiguration.class})
 public class InfinispanEmbeddedAutoConfigurationIntegrationTest {
 
     @Autowired
     EmbeddedCacheManager defaultCacheManager;
+
+    @Autowired
+    SpringEmbeddedCacheManager springEmbeddedCacheManager;
 
     @Test
     public void contextLoads() {
@@ -42,5 +47,10 @@ public class InfinispanEmbeddedAutoConfigurationIntegrationTest {
         final GlobalConfiguration globalConfiguration = defaultCacheManager.getCacheManagerConfiguration();
         assertThat(globalConfiguration.globalJmxStatistics().enabled()).isTrue();
         assertThat(globalConfiguration.globalJmxStatistics().domain()).isEqualTo(DEFAULT_JMX_DOMAIN);
+    }
+
+    @Test
+    public void testIfSpringCachingWasCreatedUsingProperEmbeddedCacheManager() throws Exception {
+        assertThat(defaultCacheManager).isEqualTo(springEmbeddedCacheManager.getNativeCacheManager());
     }
 }

--- a/inifinispan-spring-boot-starter-test-embedded/src/test/java/test/infinispan/autoconfigure/embedded/InfinispanEmbeddedAutoConfigurationPropertiesTest.java
+++ b/inifinispan-spring-boot-starter-test-embedded/src/test/java/test/infinispan/autoconfigure/embedded/InfinispanEmbeddedAutoConfigurationPropertiesTest.java
@@ -12,7 +12,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -20,7 +20,7 @@ import infinispan.autoconfigure.embedded.InfinispanEmbeddedAutoConfiguration;
 import infinispan.autoconfigure.embedded.InfinispanEmbeddedCacheManagerAutoConfiguration;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration({InfinispanEmbeddedAutoConfiguration.class, InfinispanEmbeddedCacheManagerAutoConfiguration.class})
+@SpringBootTest(classes = {InfinispanEmbeddedAutoConfiguration.class, InfinispanEmbeddedCacheManagerAutoConfiguration.class})
 @TestPropertySource(properties = "infinispan.embedded.config-xml=infinispan-test-conf.xml")
 public class InfinispanEmbeddedAutoConfigurationPropertiesTest {
 

--- a/inifinispan-spring-boot-starter-test-embedded/src/test/java/test/infinispan/autoconfigure/embedded/InfinispanEmbeddedAutoConfigurationPropertiesTest.java
+++ b/inifinispan-spring-boot-starter-test-embedded/src/test/java/test/infinispan/autoconfigure/embedded/InfinispanEmbeddedAutoConfigurationPropertiesTest.java
@@ -17,9 +17,10 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import infinispan.autoconfigure.embedded.InfinispanEmbeddedAutoConfiguration;
+import infinispan.autoconfigure.embedded.InfinispanEmbeddedCacheManagerAutoConfiguration;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(InfinispanEmbeddedAutoConfiguration.class)
+@SpringApplicationConfiguration({InfinispanEmbeddedAutoConfiguration.class, InfinispanEmbeddedCacheManagerAutoConfiguration.class})
 @TestPropertySource(properties = "infinispan.embedded.config-xml=infinispan-test-conf.xml")
 public class InfinispanEmbeddedAutoConfigurationPropertiesTest {
 

--- a/inifinispan-spring-boot-starter-test-embedded/src/test/java/test/infinispan/autoconfigure/embedded/InfinispanEmbeddedDisableTest.java
+++ b/inifinispan-spring-boot-starter-test-embedded/src/test/java/test/infinispan/autoconfigure/embedded/InfinispanEmbeddedDisableTest.java
@@ -11,10 +11,11 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import infinispan.autoconfigure.embedded.InfinispanEmbeddedAutoConfiguration;
+import infinispan.autoconfigure.embedded.InfinispanEmbeddedCacheManagerAutoConfiguration;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = {InfinispanEmbeddedAutoConfiguration.class})
-@TestPropertySource(properties = {"infinispan.embedded.enabled=false"})
+@SpringBootTest(classes = {InfinispanEmbeddedAutoConfiguration.class, InfinispanEmbeddedCacheManagerAutoConfiguration.class})
+@TestPropertySource(properties = {"infinispan.embedded.enabled=false", "infinispan.embedded.caching.enabled=false"})
 public class InfinispanEmbeddedDisableTest {
 
    @Autowired

--- a/inifinispan-spring-boot-starter-test-remote/pom.xml
+++ b/inifinispan-spring-boot-starter-test-remote/pom.xml
@@ -23,6 +23,11 @@
             <artifactId>infinispan-client-hotrod</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-spring4-remote</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/inifinispan-spring-boot-starter-test-remote/pom.xml
+++ b/inifinispan-spring-boot-starter-test-remote/pom.xml
@@ -4,16 +4,16 @@
 
     <parent>
         <groupId>org.infinispan</groupId>
-        <artifactId>inifinispan-spring-boot-starter-parent</artifactId>
+        <artifactId>infinispan-spring-boot-starter-parent</artifactId>
         <version>1.0.0.Beta1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>inifinispan-spring-boot-starter-test-remote</artifactId>
+    <artifactId>infinispan-spring-boot-starter-test-remote</artifactId>
 
     <dependencies>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>inifinispan-spring-boot-starter</artifactId>
+            <artifactId>infinispan-spring-boot-starter</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/inifinispan-spring-boot-starter-test-remote/src/test/java/test/infinispan/autoconfigure/remote/InfinispanRemoteAutoConfigurationIntegrationTest.java
+++ b/inifinispan-spring-boot-starter-test-remote/src/test/java/test/infinispan/autoconfigure/remote/InfinispanRemoteAutoConfigurationIntegrationTest.java
@@ -3,6 +3,7 @@ package test.infinispan.autoconfigure.remote;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.spring.provider.SpringRemoteCacheManager;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,15 +12,19 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import infinispan.autoconfigure.remote.InfinispanRemoteAutoConfiguration;
+import infinispan.autoconfigure.remote.InfinispanRemoteCacheManagerAutoConfiguration;
 import test.infinispan.autoconfigure.testconfiguration.InfinispanCacheTestConfiguration;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = {InfinispanRemoteAutoConfiguration.class, InfinispanCacheTestConfiguration.class})
+@SpringBootTest(classes = {InfinispanRemoteAutoConfiguration.class, InfinispanRemoteCacheManagerAutoConfiguration.class, InfinispanCacheTestConfiguration.class})
 @TestPropertySource(properties = "infinispan.remote.client-properties=test-hotrod-client.properties")
 public class InfinispanRemoteAutoConfigurationIntegrationTest {
 
    @Autowired
    private RemoteCacheManager remoteCacheManager;
+
+   @Autowired
+   private SpringRemoteCacheManager springRemoteCacheManager;
 
    @Test
    public void testConfiguredClient() {
@@ -28,5 +33,10 @@ public class InfinispanRemoteAutoConfigurationIntegrationTest {
 
       //then
       assertThat(portObtainedFromPropertiesFile).isEqualTo(InfinispanCacheTestConfiguration.PORT);
+   }
+
+   @Test
+   public void testIfSpringCachingWasCreatedUsingProperEmbeddedCacheManager() throws Exception {
+      assertThat(remoteCacheManager).isEqualTo(springRemoteCacheManager.getNativeCacheManager());
    }
 }

--- a/inifinispan-spring-boot-starter-test-remote/src/test/java/test/infinispan/autoconfigure/remote/InfinispanRemoteAutoConfigurationPropertiesTest.java
+++ b/inifinispan-spring-boot-starter-test-remote/src/test/java/test/infinispan/autoconfigure/remote/InfinispanRemoteAutoConfigurationPropertiesTest.java
@@ -11,9 +11,10 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import infinispan.autoconfigure.remote.InfinispanRemoteAutoConfiguration;
+import infinispan.autoconfigure.remote.InfinispanRemoteCacheManagerAutoConfiguration;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = { InfinispanRemoteAutoConfiguration.class})
+@SpringBootTest(classes = { InfinispanRemoteAutoConfiguration.class, InfinispanRemoteCacheManagerAutoConfiguration.class})
 @TestPropertySource(properties = "infinispan.remote.client-properties=test-hotrod-client.properties")
 public class InfinispanRemoteAutoConfigurationPropertiesTest {
 

--- a/inifinispan-spring-boot-starter-test-remote/src/test/java/test/infinispan/autoconfigure/remote/InfinispanRemoteDisableTest.java
+++ b/inifinispan-spring-boot-starter-test-remote/src/test/java/test/infinispan/autoconfigure/remote/InfinispanRemoteDisableTest.java
@@ -11,9 +11,10 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import infinispan.autoconfigure.remote.InfinispanRemoteAutoConfiguration;
+import infinispan.autoconfigure.remote.InfinispanRemoteCacheManagerAutoConfiguration;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = {InfinispanRemoteAutoConfiguration.class})
+@SpringBootTest(classes = {InfinispanRemoteAutoConfiguration.class, InfinispanRemoteCacheManagerAutoConfiguration.class})
 @TestPropertySource(properties = {"infinispan.remote.client-properties=test-hotrod-client.properties", "infinispan.remote.enabled=false"})
 public class InfinispanRemoteDisableTest {
 

--- a/inifinispan-spring-boot-starter-test-remote/src/test/java/test/infinispan/autoconfigure/remote/InfinispanRemotePreventAutoConfigurationTest.java
+++ b/inifinispan-spring-boot-starter-test-remote/src/test/java/test/infinispan/autoconfigure/remote/InfinispanRemotePreventAutoConfigurationTest.java
@@ -11,9 +11,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import infinispan.autoconfigure.remote.InfinispanRemoteAutoConfiguration;
+import infinispan.autoconfigure.remote.InfinispanRemoteCacheManagerAutoConfiguration;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = { InfinispanRemoteAutoConfiguration.class})
+@SpringBootTest(classes = { InfinispanRemoteAutoConfiguration.class, InfinispanRemoteCacheManagerAutoConfiguration.class})
 public class InfinispanRemotePreventAutoConfigurationTest {
 
     @Autowired

--- a/inifinispan-spring-boot-starter/pom.xml
+++ b/inifinispan-spring-boot-starter/pom.xml
@@ -4,16 +4,16 @@
 
     <parent>
         <groupId>org.infinispan</groupId>
-        <artifactId>inifinispan-spring-boot-starter-parent</artifactId>
+        <artifactId>infinispan-spring-boot-starter-parent</artifactId>
         <version>1.0.0.Beta1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>inifinispan-spring-boot-starter</artifactId>
+    <artifactId>infinispan-spring-boot-starter</artifactId>
 
     <dependencies>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>inifinispan-spring-boot-starter-autoconfigure</artifactId>
+            <artifactId>infinispan-spring-boot-starter-autoconfigure</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <groupId>org.infinispan</groupId>
-    <artifactId>inifinispan-spring-boot-starter-parent</artifactId>
+    <artifactId>infinispan-spring-boot-starter-parent</artifactId>
     <version>1.0.0.Beta1-SNAPSHOT</version>
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <spring-boot.version>1.4.0.RELEASE</spring-boot.version>
-        <infinispan.version>8.2.4.Final</infinispan.version>
-        <assertj.version>3.5.2</assertj.version>
+        <spring-boot.version>1.5.1.RELEASE</spring-boot.version>
+        <infinispan.version>8.2.5.Final</infinispan.version>
+        <assertj.version>3.6.2</assertj.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7468

* The integration checks if SpringEmbeddedCacheManager or SpringEmbeddedCacheManagerFactoryBean is present on the classpath and creates default instances if they are not (this also applies to remote version of those classes)
* All conditions have been changed into String versions because of https://github.com/spring-projects/spring-boot/issues/1733
** Note: Although we are based on newer version of Spring Boot, someone might want to use the old one