### PR TITLE
test near cache config

### DIFF
--- a/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/CustomPropertiesTest.java
+++ b/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/CustomPropertiesTest.java
@@ -1,5 +1,7 @@
 package test.org.infinispan.spring.starter.remote;
 
+import org.infinispan.client.hotrod.configuration.NearCacheConfiguration;
+import org.infinispan.client.hotrod.configuration.NearCacheMode;
 import org.infinispan.spring.starter.remote.InfinispanRemoteAutoConfiguration;
 import org.infinispan.spring.starter.remote.InfinispanRemoteCacheManagerAutoConfiguration;
 import org.infinispan.client.hotrod.RemoteCacheManager;
@@ -11,6 +13,8 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.regex.Pattern;
 
 @DirtiesContext
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -31,12 +35,16 @@ public class CustomPropertiesTest {
 
     @Test
     public void testDefaultClient() {
-        //when
         int portObtainedFromPropertiesFile = remoteCacheManager.getConfiguration().servers().get(0).port();
         boolean tcpNoDelay = remoteCacheManager.getConfiguration().tcpNoDelay();
 
-        //then
         assertThat(portObtainedFromPropertiesFile).isEqualTo(6667);
         assertThat(tcpNoDelay).isFalse();
+
+        NearCacheConfiguration nearCacheConfiguration = remoteCacheManager.getConfiguration().nearCache();
+
+        assertThat(nearCacheConfiguration.maxEntries()).isEqualTo(1000);
+        assertThat(nearCacheConfiguration.mode()).isEqualTo(NearCacheMode.INVALIDATED);
+        assertThat(nearCacheConfiguration.cacheNamePattern().toString()).isEqualTo("cus*");
     }
 }

--- a/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/IntegrationTest.java
+++ b/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/IntegrationTest.java
@@ -1,5 +1,7 @@
 package test.org.infinispan.spring.starter.remote;
 
+import org.infinispan.client.hotrod.configuration.Configuration;
+import org.infinispan.client.hotrod.configuration.NearCacheMode;
 import org.infinispan.spring.starter.remote.InfinispanRemoteAutoConfiguration;
 import org.infinispan.spring.starter.remote.InfinispanRemoteCacheManagerAutoConfiguration;
 import org.infinispan.client.hotrod.RemoteCacheManager;
@@ -37,11 +39,11 @@ public class IntegrationTest {
 
    @Test
    public void testConfiguredClient() {
-      //when
-      int portObtainedFromPropertiesFile = remoteCacheManager.getConfiguration().servers().get(0).port();
+      Configuration configuration = remoteCacheManager.getConfiguration();
 
-      //then
-      assertThat(portObtainedFromPropertiesFile).isEqualTo(InfinispanCacheTestConfiguration.PORT);
+      assertThat(configuration.servers().get(0).port()).isEqualTo(InfinispanCacheTestConfiguration.PORT);
+      assertThat(configuration.nearCache().mode()).isEqualTo(NearCacheMode.INVALIDATED);
+      assertThat(configuration.nearCache().maxEntries()).isEqualTo(InfinispanCacheTestConfiguration.NEAR_CACHE_MAX_ENTRIES);
    }
 
    @Test

--- a/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/testconfiguration/InfinispanCacheTestConfiguration.java
+++ b/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/testconfiguration/InfinispanCacheTestConfiguration.java
@@ -10,9 +10,12 @@ import org.infinispan.spring.starter.remote.InfinispanRemoteConfigurer;
 public class InfinispanCacheTestConfiguration {
 
    public static final int PORT = 11555;
+   public static final int NEAR_CACHE_MAX_ENTRIES = 150;
 
    @Bean
    public InfinispanRemoteConfigurer infinispanRemoteConfigurer() {
-      return () -> new ConfigurationBuilder().addServer().host("127.0.0.1").port(PORT).build();
+      return () -> new ConfigurationBuilder()
+            .nearCache().maxEntries(NEAR_CACHE_MAX_ENTRIES)
+            .addServer().host("127.0.0.1").port(PORT).build();
    }
 }

--- a/infinispan-spring-boot-starter-remote/src/test/resources/test-hotrod-client.properties
+++ b/infinispan-spring-boot-starter-remote/src/test/resources/test-hotrod-client.properties
@@ -1,2 +1,7 @@
 infinispan.client.hotrod.server_list=127.0.0.1:6667
 infinispan.client.hotrod.tcp_no_delay=false
+
+#near caching
+infinispan.client.hotrod.near_cache.max_entries=1000
+infinispan.client.hotrod.near_cache.mode=INVALIDATED
+infinispan.client.hotrod.near_cache.name_pattern=cus*

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <spring-boot.version>2.0.3.RELEASE</spring-boot.version>
-        <infinispan.version>9.3.0.Final</infinispan.version>
+        <infinispan.version>9.4.0-SNAPSHOT</infinispan.version>
         <assertj.version>3.8.0</assertj.version>
     </properties>
 


### PR DESCRIPTION
I've been playing with Infinispan 9.4.0-SNAPSHOT branch master, where we added the possibility to configure near caching via the hotrod properties file. Which is fine (```CustomPropertiesTest```).

What is weird to me is the ```IntegrationTest```

We provide a ```InfinispanCacheTestConfiguration``` where I set the near cache entries to 150.
So this class is used to configure the remote cache manager. Every other configuration is ignored.
But the test specifically provides ```infinispan.remote.client-properties=test-hotrod-client.properties``` which should be optional since we are passing the configuration by code.
If I remove properties file, the remote cache manager can't be created and the test fails.

This is weird to me because it looks like I need to provide an infinispan properties, but this file is not used to configure the remote infinispan manager since we are doing this by code.

