### PR TITLE
Make spring-boot-configuration-processor dependency optional

### DIFF
--- a/infinispan-spring-boot-starter-embedded/pom.xml
+++ b/infinispan-spring-boot-starter-embedded/pom.xml
@@ -17,6 +17,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
     </dependency>
 
     <dependency>

--- a/infinispan-spring-boot-starter-remote/pom.xml
+++ b/infinispan-spring-boot-starter-remote/pom.xml
@@ -17,6 +17,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
`spring-boot-configuration-processor` should not be transient
dependency. This commit makes the dependency optional so it is not
passed transitively.