### PR TITLE
Add spring boot configuration processor dependency

### DIFF
--- a/infinispan-spring-boot-starter-embedded/pom.xml
+++ b/infinispan-spring-boot-starter-embedded/pom.xml
@@ -19,6 +19,11 @@
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>org.infinispan</groupId>

--- a/infinispan-spring-boot-starter-remote/pom.xml
+++ b/infinispan-spring-boot-starter-remote/pom.xml
@@ -19,6 +19,11 @@
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>org.infinispan</groupId>


### PR DESCRIPTION
This dependency generate metadata needed to help Spring Boot with the
startup time.