### PR TITLE
Add additional-spring-configuration-metadata.json

### DIFF
--- a/infinispan-spring-boot-starter-embedded/src/main/java/org/infinispan/spring/starter/embedded/InfinispanEmbeddedConfigurationProperties.java
+++ b/infinispan-spring-boot-starter-embedded/src/main/java/org/infinispan/spring/starter/embedded/InfinispanEmbeddedConfigurationProperties.java
@@ -7,11 +7,6 @@ public class InfinispanEmbeddedConfigurationProperties {
     public static final String DEFAULT_CLUSTER_NAME = "default-autoconfigure";
 
     /**
-     * Enable embedded cache.
-     */
-    private boolean enabled = true;
-
-    /**
      * The configuration file to use as a template for all caches created.
      */
     private String configXml = "";
@@ -47,11 +42,4 @@ public class InfinispanEmbeddedConfigurationProperties {
         this.clusterName = clusterName;
     }
 
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
 }

--- a/infinispan-spring-boot-starter-embedded/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/infinispan-spring-boot-starter-embedded/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,16 @@
+{
+  "properties": [
+    {
+      "name": "infinispan.embedded.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable Embedded Infinispan.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "infinispan.embedded.cache.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable Embedded Infinispan's cache support.",
+      "defaultValue": "true"
+    }
+  ]
+}

--- a/infinispan-spring-boot-starter-remote/src/main/java/org/infinispan/spring/starter/remote/InfinispanRemoteConfigurationProperties.java
+++ b/infinispan-spring-boot-starter-remote/src/main/java/org/infinispan/spring/starter/remote/InfinispanRemoteConfigurationProperties.java
@@ -8,11 +8,6 @@ public class InfinispanRemoteConfigurationProperties {
     public static final String DEFAULT_CLIENT_PROPERTIES = "classpath:hotrod-client.properties";
 
     /**
-     * Enable remote cache.
-     */
-    private boolean enabled = true;
-
-    /**
      * The hotrod client properties location.
      */
     private String clientProperties = DEFAULT_CLIENT_PROPERTIES;
@@ -45,14 +40,6 @@ public class InfinispanRemoteConfigurationProperties {
 
     public void setClientProperties(String clientProperties) {
         this.clientProperties = clientProperties;
-    }
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
     }
 
     public String getServerList() {

--- a/infinispan-spring-boot-starter-remote/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/infinispan-spring-boot-starter-remote/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,16 @@
+{
+  "properties": [
+    {
+      "name": "infinispan.remote.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable Remote Infinispan.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "infinispan.remote.cache.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable Embedded Infinispan's cache support.",
+      "defaultValue": "true"
+    }
+  ]
+}


### PR DESCRIPTION
Currently, `enabled` is provided by Infinispan*ConfigurationProperties
without being used. This property is now provided in the additional-spring-configuration-metadata.json
together with `infinispan.*.cache.enabled`. This enhancement will help
users when looking for properties in the IDEs.