### PR TITLE
Upgrade 2.1.3.RELEASE and fix samples pom

### DIFF
--- a/Jenkinsfile-release
+++ b/Jenkinsfile-release
@@ -21,8 +21,7 @@ pipeline {
                 script {
                     env.MAVEN_HOME = tool('Maven')
                     env.MAVEN_OPTS = "-Xmx800m -XX:+HeapDumpOnOutOfMemoryError"
-                    env.JAVA_HOME = tool('JDK 8')
-                    env.JAVA10_HOME = tool('JDK 10')
+                    env.JAVA_HOME = tool('JDK 11')
                 }
 
                 sh returnStdout: true, script: 'cleanup.sh'
@@ -53,7 +52,7 @@ pipeline {
 
         stage('Deploy') {
             steps {
-                sh "$MAVEN_HOME/bin/mvn -B -V -Pdistribution -DskipTests clean deploy -DstagingRepositoryId=$STAGING_REPO_ID -Djava10.home=$JAVA10_HOME"
+                sh "$MAVEN_HOME/bin/mvn -B -V -Pdistribution -DskipTests clean deploy -DstagingRepositoryId=$STAGING_REPO_ID"
             }
         }
 

--- a/infinispan-spring-boot-samples/README.adoc
+++ b/infinispan-spring-boot-samples/README.adoc
@@ -23,7 +23,7 @@ Use docker or download and run the http://infinispan.org/download/[Infinispan Se
 [source,bash]
 .Docker
 ----
-docker run -it -p 11222:11222 jboss/infinispan-server:9.4.5.Final
+docker run -it -p 11222:11222 jboss/infinispan-server:latest
 ----
 
 [source,bash]
@@ -41,11 +41,20 @@ Cache metrics are prefixed by *"cache."*
 http://localhost:8080/actuator/metrics
 
 Display each metric for each cache using tags. For example for the 'puts' stats in the basque-names cache:
+
 http://localhost:8080/actuator/metrics/cache.puts?tag=name:basque-names
 
 
 == Run Prometheus
 
-For docker for mac or windows, execute `run-prometheus.sh`.
-The `prometheus.yml` file contains the _host.docker.internal_ binding that will allow prometheus scrap the metrics exposed by spring actuator.
+The `prometheus.yml` file contains the _host.docker.internal_ binding that will allow prometheus scrap the metrics
+exposed by spring actuator.
+
+Change the `YOUR_PATH` value to the folder you are running prometheus from.
+
+[source,bash]
+.Docker
+----
+docker run -d --name=prometheus -p 9090:9090 -v YOUR_PATH/infinispan-spring-boot/infinispan-spring-boot-samples/prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus --config.file=/etc/prometheus/prometheus.yml
+----
 

--- a/infinispan-spring-boot-samples/embedded/pom.xml
+++ b/infinispan-spring-boot-samples/embedded/pom.xml
@@ -38,4 +38,13 @@
 
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/infinispan-spring-boot-samples/remote/pom.xml
+++ b/infinispan-spring-boot-samples/remote/pom.xml
@@ -37,4 +37,14 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/infinispan-spring-boot-samples/run-prometheus.sh
+++ b/infinispan-spring-boot-samples/run-prometheus.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-docker run -d --name=prometheus -p 9090:9090 -v /Users/katiaaresti/REDHAT/SPRING/infinispan-spring-boot/infinispan-spring-boot-samples/prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus --config.file=/etc/prometheus/prometheus.yml

--- a/infinispan-spring-boot-starter-remote/pom.xml
+++ b/infinispan-spring-boot-starter-remote/pom.xml
@@ -134,7 +134,7 @@
         <plugin>
           <groupId>org.wildfly.plugins</groupId>
           <artifactId>wildfly-maven-plugin</artifactId>
-          <version>1.1.0.Alpha6</version>
+          <version>${version.maven.wildfly-plugin}</version>
           <executions>
             <execution>
               <id>start-server</id>

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.jboss</groupId>
-        <artifactId>jboss-parent</artifactId>
-        <version>21</version>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-build-configuration-parent</artifactId>
+        <version>9.4.8.Final</version>
     </parent>
 
     <groupId>org.infinispan</groupId>
@@ -54,18 +54,16 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <spring-boot.version>2.1.2.RELEASE</spring-boot.version>
-        <infinispan.version>9.4.6.Final</infinispan.version>
+        <spring-boot.version>2.1.3.RELEASE</spring-boot.version>
+        <infinispan.version>9.4.8.Final</infinispan.version>
         <assertj.version>3.11.1</assertj.version>
         <junit.jupiter.version>5.3.1</junit.jupiter.version>
         <infinispan-springboot.brand.name>Infinispan Spring Boot</infinispan-springboot.brand.name>
         <jboss.releases.nexus.url>https://repository.jboss.org/nexus</jboss.releases.nexus.url>
         <jboss.releases.repo.id>jboss-releases-repository</jboss.releases.repo.id>
         <jboss.releases.repo.url>${jboss.releases.nexus.url}/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
-        <version.checkstyle>8.1</version.checkstyle>
-        <version.checkstyle.maven-plugin>2.17</version.checkstyle.maven-plugin>
-        <version.maven.failsafe>2.22.0</version.maven.failsafe>
-        <version.maven.surefire>2.22.0</version.maven.surefire>
+        <version.maven.failsafe>3.0.0-M3</version.maven.failsafe>
+        <version.maven.wildfly-plugin>2.0.1.Final</version.maven.wildfly-plugin>
     </properties>
 
     <profiles>
@@ -182,11 +180,6 @@
         </plugins>
         </pluginManagement>
         <plugins>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring-boot.version}</version>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9984

- The spring-boot maven plugin must be placed in the `pom.xml` where we want to run spring-boot:run

- Upgraded the reinforce plugin that was failing the build in java 11

- Upgraded SB 2.1.3.RELEASE

- Upgraded Infinispan 9.4.8.Final

- Using the correct wildfly maven plugin

Closes https://github.com/infinispan/infinispan-spring-boot/issues/101
