### PR TITLE
ISPN-10122 Avoid Jmx registration exception on startup

### DIFF
--- a/infinispan-spring-boot-samples/remote/src/main/resources/application.properties
+++ b/infinispan-spring-boot-samples/remote/src/main/resources/application.properties
@@ -7,5 +7,6 @@ infinispan.remote.near-cache-max-entries=100
 
 # activates statistics for actuator
 infinispan.remote.statistics=true
+infinispan.remote.jmx=true
 
 management.endpoints.web.exposure.include=*

--- a/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfigurationCustomizerIntegrationTest.java
+++ b/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfigurationCustomizerIntegrationTest.java
@@ -12,25 +12,20 @@ import org.infinispan.spring.starter.embedded.InfinispanEmbeddedAutoConfiguratio
 import org.infinispan.spring.starter.embedded.InfinispanEmbeddedCacheManagerAutoConfiguration;
 import org.infinispan.spring.starter.embedded.InfinispanGlobalConfigurationCustomizer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@DirtiesContext
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
-   classes = {
-      InfinispanEmbeddedAutoConfiguration.class,
-      InfinispanEmbeddedCacheManagerAutoConfiguration.class,
-      InfinispanEmbeddedAutoConfigurationCustomizerIntegrationTest.TestConfiguration.class
-   },
-   properties = {
-      "spring.main.banner-mode=off"
-   }
+      classes = {
+            InfinispanEmbeddedAutoConfiguration.class,
+            InfinispanEmbeddedCacheManagerAutoConfiguration.class,
+            InfinispanEmbeddedAutoConfigurationCustomizerIntegrationTest.TestConfiguration.class
+      },
+      properties = {
+            "spring.main.banner-mode=off"
+      }
 )
 public class InfinispanEmbeddedAutoConfigurationCustomizerIntegrationTest {
    private static final String CLUSTER_NAME = UUID.randomUUID().toString();
@@ -53,10 +48,10 @@ public class InfinispanEmbeddedAutoConfigurationCustomizerIntegrationTest {
       @Bean(name = "small-cache")
       public org.infinispan.configuration.cache.Configuration smallCache() {
          return new ConfigurationBuilder()
-             .simpleCache(true)
-             .memory().size(1000L)
-             .memory().evictionType(EvictionType.COUNT)
-             .build();
+               .simpleCache(true)
+               .memory().size(1000L)
+               .memory().evictionType(EvictionType.COUNT)
+               .build();
       }
 
       @Bean

--- a/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfigurationIntegrationConfigurationTest.java
+++ b/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfigurationIntegrationConfigurationTest.java
@@ -7,15 +7,12 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.spring.starter.embedded.InfinispanEmbeddedAutoConfiguration;
 import org.infinispan.spring.starter.embedded.InfinispanEmbeddedCacheManagerAutoConfiguration;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import test.org.infinispan.spring.starter.embedded.testconfiguration.InfinispanCacheConfigurationBaseTestConfiguration;
 import test.org.infinispan.spring.starter.embedded.testconfiguration.InfinispanCacheConfigurationTestConfiguration;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
       classes = {
             InfinispanEmbeddedAutoConfiguration.class,

--- a/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfigurationIntegrationConfigurerTest.java
+++ b/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfigurationIntegrationConfigurerTest.java
@@ -13,14 +13,11 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.spring.starter.embedded.InfinispanEmbeddedAutoConfiguration;
 import org.infinispan.spring.starter.embedded.InfinispanEmbeddedCacheManagerAutoConfiguration;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import test.org.infinispan.spring.starter.embedded.testconfiguration.InfinispanCacheTestConfiguration;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
       classes = {
             InfinispanEmbeddedAutoConfiguration.class,

--- a/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfigurationIntegrationTest.java
+++ b/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfigurationIntegrationTest.java
@@ -10,20 +10,17 @@ import org.infinispan.spring.embedded.provider.SpringEmbeddedCacheManager;
 import org.infinispan.spring.starter.embedded.InfinispanEmbeddedAutoConfiguration;
 import org.infinispan.spring.starter.embedded.InfinispanEmbeddedCacheManagerAutoConfiguration;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
-    classes = {
-        InfinispanEmbeddedAutoConfiguration.class,
-        InfinispanEmbeddedCacheManagerAutoConfiguration.class
-    },
-    properties = {
-        "spring.main.banner-mode=off"
-    }
+      classes = {
+            InfinispanEmbeddedAutoConfiguration.class,
+            InfinispanEmbeddedCacheManagerAutoConfiguration.class
+      },
+      properties = {
+            "spring.main.banner-mode=off"
+      }
 )
 public class InfinispanEmbeddedAutoConfigurationIntegrationTest {
 

--- a/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfigurationPropertiesTest.java
+++ b/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfigurationPropertiesTest.java
@@ -10,13 +10,10 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.spring.starter.embedded.InfinispanEmbeddedAutoConfiguration;
 import org.infinispan.spring.starter.embedded.InfinispanEmbeddedCacheManagerAutoConfiguration;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
       classes = {
             InfinispanEmbeddedAutoConfiguration.class,

--- a/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/InfinispanEmbeddedDisableTest.java
+++ b/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/InfinispanEmbeddedDisableTest.java
@@ -7,23 +7,20 @@ import org.infinispan.spring.starter.embedded.InfinispanEmbeddedAutoConfiguratio
 import org.infinispan.spring.starter.embedded.InfinispanEmbeddedCacheManagerAutoConfiguration;
 import org.infinispan.spring.starter.embedded.actuator.InfinispanCacheMeterBinderProvider;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
-    classes = {
-        InfinispanEmbeddedAutoConfiguration.class,
-        InfinispanEmbeddedCacheManagerAutoConfiguration.class
-    },
-    properties = {
-        "spring.main.banner-mode=off",
-        "infinispan.embedded.enabled=false",
-        "infinispan.embedded.caching.enabled=true"
-    }
+      classes = {
+            InfinispanEmbeddedAutoConfiguration.class,
+            InfinispanEmbeddedCacheManagerAutoConfiguration.class
+      },
+      properties = {
+            "spring.main.banner-mode=off",
+            "infinispan.embedded.enabled=false",
+            "infinispan.embedded.caching.enabled=true"
+      }
 )
 public class InfinispanEmbeddedDisableTest {
 

--- a/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/InfinispanEmbeddedEnableTest.java
+++ b/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/InfinispanEmbeddedEnableTest.java
@@ -7,23 +7,20 @@ import org.infinispan.spring.starter.embedded.InfinispanEmbeddedAutoConfiguratio
 import org.infinispan.spring.starter.embedded.InfinispanEmbeddedCacheManagerAutoConfiguration;
 import org.infinispan.spring.starter.embedded.actuator.InfinispanCacheMeterBinderProvider;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
-    classes = {
-        InfinispanEmbeddedAutoConfiguration.class,
-        InfinispanEmbeddedCacheManagerAutoConfiguration.class
-    },
-    properties = {
-        "spring.main.banner-mode=off",
-        "infinispan.embedded.enabled=true",
-        "infinispan.embedded.caching.enabled=true"
-    }
+      classes = {
+            InfinispanEmbeddedAutoConfiguration.class,
+            InfinispanEmbeddedCacheManagerAutoConfiguration.class
+      },
+      properties = {
+            "spring.main.banner-mode=off",
+            "infinispan.embedded.enabled=true",
+            "infinispan.embedded.caching.enabled=true"
+      }
 )
 public class InfinispanEmbeddedEnableTest {
 

--- a/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/actuator/InfinispanCacheMetricBinderTest.java
+++ b/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/actuator/InfinispanCacheMetricBinderTest.java
@@ -8,13 +8,10 @@ import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.spring.starter.embedded.actuator.InfinispanCacheMeterBinder;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import io.micrometer.core.instrument.binder.cache.CacheMeterBinder;
 import io.micrometer.core.instrument.binder.cache.CacheMeterBinderCompatibilityKit;
 
-@ExtendWith(SpringExtension.class)
 public class InfinispanCacheMetricBinderTest extends CacheMeterBinderCompatibilityKit {
 
    private static EmbeddedCacheManager cacheManager;

--- a/infinispan-spring-boot-starter-remote/src/main/java/org/infinispan/spring/starter/remote/InfinispanJmxConfiguration.java
+++ b/infinispan-spring-boot-starter-remote/src/main/java/org/infinispan/spring/starter/remote/InfinispanJmxConfiguration.java
@@ -1,0 +1,31 @@
+package org.infinispan.spring.starter.remote;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jmx.export.MBeanExporter;
+
+/**
+ * Spring and Infinispan register the same bean. Avoid an exception telling Spring not to export Infinispan's
+ * bean
+ *
+ * @since 2.1.x
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "infinispan.remote", name = "jmx", havingValue = "true")
+public class InfinispanJmxConfiguration {
+
+   private final ObjectProvider<MBeanExporter> mBeanExporter;
+
+   InfinispanJmxConfiguration(ObjectProvider<MBeanExporter> mBeanExporter) {
+      this.mBeanExporter = mBeanExporter;
+   }
+
+   @PostConstruct
+   public void excludeRemoteCacheManagerMBean() {
+      this.mBeanExporter
+            .ifUnique((exporter) -> exporter.addExcludedBean("remoteCacheManager"));
+   }
+}

--- a/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/ApplicationPropertiesTest.java
+++ b/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/ApplicationPropertiesTest.java
@@ -21,13 +21,10 @@ import org.infinispan.client.hotrod.security.BasicCallbackHandler;
 import org.infinispan.spring.starter.remote.InfinispanRemoteAutoConfiguration;
 import org.infinispan.spring.starter.remote.InfinispanRemoteCacheManagerAutoConfiguration;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
       classes = {
             InfinispanRemoteAutoConfiguration.class,

--- a/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/CustomConfigurationTest.java
+++ b/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/CustomConfigurationTest.java
@@ -7,16 +7,13 @@ import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.spring.starter.remote.InfinispanRemoteAutoConfiguration;
 import org.infinispan.spring.starter.remote.InfinispanRemoteCacheCustomizer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
       classes = {
             CustomConfigurationTest.TestConfiguration.class,

--- a/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/CustomConfigurerWithPropertyInjectionTest.java
+++ b/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/CustomConfigurerWithPropertyInjectionTest.java
@@ -7,24 +7,21 @@ import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.spring.starter.remote.InfinispanRemoteAutoConfiguration;
 import org.infinispan.spring.starter.remote.InfinispanRemoteConfigurer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
-    classes = {
-        CustomConfigurerWithPropertyInjectionTest.TestConfiguration.class,
-        InfinispanRemoteAutoConfiguration.class
-    },
-    properties = {
-        "spring.main.banner-mode=off",
-        "myServerList=localhost:6667"
-    }
+      classes = {
+            CustomConfigurerWithPropertyInjectionTest.TestConfiguration.class,
+            InfinispanRemoteAutoConfiguration.class
+      },
+      properties = {
+            "spring.main.banner-mode=off",
+            "myServerList=localhost:6667"
+      }
 )
 public class CustomConfigurerWithPropertyInjectionTest {
    @Autowired
@@ -43,8 +40,8 @@ public class CustomConfigurerWithPropertyInjectionTest {
       @Bean
       public InfinispanRemoteConfigurer configuration() {
          return () -> new ConfigurationBuilder()
-             .addServers(serverList)
-             .build();
+               .addServers(serverList)
+               .build();
       }
    }
 }

--- a/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/CustomPropertiesTest.java
+++ b/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/CustomPropertiesTest.java
@@ -21,12 +21,9 @@ import org.infinispan.client.hotrod.security.BasicCallbackHandler;
 import org.infinispan.spring.starter.remote.InfinispanRemoteAutoConfiguration;
 import org.infinispan.spring.starter.remote.InfinispanRemoteCacheManagerAutoConfiguration;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
       classes = {
             InfinispanRemoteAutoConfiguration.class,

--- a/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/DisablingTest.java
+++ b/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/DisablingTest.java
@@ -6,13 +6,10 @@ import org.infinispan.spring.starter.remote.InfinispanRemoteAutoConfiguration;
 import org.infinispan.spring.starter.remote.InfinispanRemoteCacheManagerAutoConfiguration;
 import org.infinispan.spring.starter.remote.actuator.RemoteInfinispanCacheMeterBinderProvider;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
       classes = {
             InfinispanRemoteAutoConfiguration.class,

--- a/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/EnablingTest.java
+++ b/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/EnablingTest.java
@@ -6,13 +6,10 @@ import org.infinispan.spring.starter.remote.InfinispanRemoteAutoConfiguration;
 import org.infinispan.spring.starter.remote.InfinispanRemoteCacheManagerAutoConfiguration;
 import org.infinispan.spring.starter.remote.actuator.RemoteInfinispanCacheMeterBinderProvider;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
       classes = {
             InfinispanRemoteAutoConfiguration.class,

--- a/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/InfinispanJmxConfigurationTest.java
+++ b/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/InfinispanJmxConfigurationTest.java
@@ -1,0 +1,40 @@
+package test.org.infinispan.spring.starter.remote;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.spring.starter.remote.InfinispanJmxConfiguration;
+import org.infinispan.spring.starter.remote.InfinispanRemoteAutoConfiguration;
+import org.infinispan.spring.starter.remote.InfinispanRemoteCacheManagerAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jmx.export.MBeanExporter;
+
+import test.org.infinispan.spring.starter.remote.testconfiguration.InfinispanCacheTestConfiguration;
+
+@SpringBootTest(classes = {
+      InfinispanRemoteAutoConfiguration.class,
+      InfinispanRemoteCacheManagerAutoConfiguration.class,
+      InfinispanJmxConfiguration.class,
+      InfinispanCacheTestConfiguration.class,
+      MBeanExporter.class},
+      properties = {
+            "spring.main.banner-mode=off",
+            "infinispan.remote.server-list=180.567.112.333:6668",
+            "infinispan.remote.jmx=true",
+            "infinispan.remote.enabled=true"})
+public class InfinispanJmxConfigurationTest {
+
+   @Autowired
+   RemoteCacheManager remoteCacheManager;
+
+   @Test
+   public void contextIsUp() {
+      /**
+       *  When JMX is enabled in Spring and Infinispan, if {@link InfinispanJmxConfiguration} does not exclude
+       *  'remoteCacheManager', this test will fail because context won't start
+       */
+      assertThat(remoteCacheManager).isNotNull();
+   }
+}

--- a/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/IntegrationTest.java
+++ b/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/IntegrationTest.java
@@ -7,24 +7,21 @@ import org.infinispan.spring.remote.provider.SpringRemoteCacheManager;
 import org.infinispan.spring.starter.remote.InfinispanRemoteAutoConfiguration;
 import org.infinispan.spring.starter.remote.InfinispanRemoteCacheManagerAutoConfiguration;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import test.org.infinispan.spring.starter.remote.testconfiguration.InfinispanCacheTestConfiguration;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
-    classes = {
-      InfinispanRemoteAutoConfiguration.class,
-      InfinispanRemoteCacheManagerAutoConfiguration.class,
-      InfinispanCacheTestConfiguration.class
-    },
-    properties = {
-        "spring.main.banner-mode=off",
-        "infinispan.remote.client-properties=test-hotrod-client.properties"
-    }
+      classes = {
+            InfinispanRemoteAutoConfiguration.class,
+            InfinispanRemoteCacheManagerAutoConfiguration.class,
+            InfinispanCacheTestConfiguration.class
+      },
+      properties = {
+            "spring.main.banner-mode=off",
+            "infinispan.remote.client-properties=test-hotrod-client.properties"
+      }
 )
 public class IntegrationTest {
 

--- a/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/PreventingAutoCreatingBeansTest.java
+++ b/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/PreventingAutoCreatingBeansTest.java
@@ -6,13 +6,10 @@ import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.spring.starter.remote.InfinispanRemoteAutoConfiguration;
 import org.infinispan.spring.starter.remote.InfinispanRemoteCacheManagerAutoConfiguration;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
       classes = {
             InfinispanRemoteAutoConfiguration.class,

--- a/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/actuator/RemoteCacheMetricBinderTest.java
+++ b/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/actuator/RemoteCacheMetricBinderTest.java
@@ -8,8 +8,6 @@ import org.infinispan.spring.common.provider.SpringCache;
 import org.infinispan.spring.starter.remote.actuator.RemoteInfinispanCacheMeterBinderProvider;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -17,7 +15,6 @@ import io.micrometer.core.instrument.binder.cache.CacheMeterBinder;
 import io.micrometer.core.instrument.binder.cache.CacheMeterBinderCompatibilityKit;
 import test.org.infinispan.spring.starter.remote.container.InfinispanContainer;
 
-@ExtendWith(SpringExtension.class)
 @Testcontainers
 public class RemoteCacheMetricBinderTest extends CacheMeterBinderCompatibilityKit {
    @Container
@@ -28,7 +25,6 @@ public class RemoteCacheMetricBinderTest extends CacheMeterBinderCompatibilityKi
 
    @AfterAll
    public static void cleanup() {
-      cacheManager.stop();
       INFINISPAN_SERVER.stop();
    }
 

--- a/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/container/InfinispanContainer.java
+++ b/infinispan-spring-boot-starter-remote/src/test/java/test/org/infinispan/spring/starter/remote/container/InfinispanContainer.java
@@ -1,6 +1,5 @@
 package test.org.infinispan.spring.starter.remote.container;
 
-
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ClientIntelligence;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
@@ -8,8 +7,7 @@ import org.testcontainers.containers.GenericContainer;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
 
-@SuppressWarnings("unchecked")
-public class InfinispanContainer extends GenericContainer {
+public class InfinispanContainer extends GenericContainer<InfinispanContainer> {
 
    private String cacheName;
    private RemoteCacheManager cacheManager;
@@ -42,7 +40,9 @@ public class InfinispanContainer extends GenericContainer {
             .statistics().jmxEnable();
 
       cacheManager = new RemoteCacheManager(configBuilder.build());
-      getCacheManager().administration().createCache(cacheName, "default");
+      if (cacheName != null) {
+         getCacheManager().administration().createCache(cacheName, "default");
+      }
    }
 
    @Override

--- a/infinispan-spring-boot-starter/src/test/java/test/infinispan/autoconfigure/CacheDisabledTest.java
+++ b/infinispan-spring-boot-starter/src/test/java/test/infinispan/autoconfigure/CacheDisabledTest.java
@@ -8,15 +8,12 @@ import org.infinispan.spring.starter.remote.InfinispanRemoteAutoConfiguration;
 import org.infinispan.spring.starter.remote.InfinispanRemoteCacheManagerAutoConfiguration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
       classes = {
             CacheAutoConfiguration.class,

--- a/infinispan-spring-boot-starter/src/test/java/test/infinispan/autoconfigure/CacheManagerTest.java
+++ b/infinispan-spring-boot-starter/src/test/java/test/infinispan/autoconfigure/CacheManagerTest.java
@@ -9,13 +9,10 @@ import org.infinispan.spring.starter.embedded.InfinispanEmbeddedCacheManagerAuto
 import org.infinispan.spring.starter.remote.InfinispanRemoteAutoConfiguration;
 import org.infinispan.spring.starter.remote.InfinispanRemoteCacheManagerAutoConfiguration;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
       classes = {
             InfinispanRemoteAutoConfiguration.class,


### PR DESCRIPTION
Infinispan in client/server mode registers a Jmx bean (when Jmx is enabled), and spring tries to register the bean too. This PR contains
* some cleanup on tests 
* the correction to tell spring not to register the bean (provided by the spring-boot team)

https://issues.jboss.org/browse/ISPN-10122