### PR TITLE
Add possibility to cache meter binder overriding

### DIFF
--- a/infinispan-spring-boot-starter-embedded/src/main/java/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfiguration.java
+++ b/infinispan-spring-boot-starter-embedded/src/main/java/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfiguration.java
@@ -17,12 +17,10 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ComponentScan
 @AutoConfigureBefore(CacheAutoConfiguration.class)
 //Since a jar with configuration might be missing (which would result in TypeNotPresentExceptionProxy), we need to
 //use String based methods.

--- a/infinispan-spring-boot-starter-embedded/src/main/java/org/infinispan/spring/starter/embedded/InfinispanEmbeddedCacheManagerAutoConfiguration.java
+++ b/infinispan-spring-boot-starter-embedded/src/main/java/org/infinispan/spring/starter/embedded/InfinispanEmbeddedCacheManagerAutoConfiguration.java
@@ -7,11 +7,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ComponentScan
 //Since a jar with configuration might be missing (which would result in TypeNotPresentExceptionProxy), we need to
 //use String based methods.
 //See https://github.com/spring-projects/spring-boot/issues/1733

--- a/infinispan-spring-boot-starter-embedded/src/main/java/org/infinispan/spring/starter/embedded/actuator/InfinispanCacheMeterBinderProvider.java
+++ b/infinispan-spring-boot-starter-embedded/src/main/java/org/infinispan/spring/starter/embedded/actuator/InfinispanCacheMeterBinderProvider.java
@@ -1,13 +1,8 @@
 package org.infinispan.spring.starter.embedded.actuator;
 
 import io.micrometer.core.instrument.binder.cache.JCacheMetrics;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.metrics.cache.CacheMeterBinderProvider;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cache.Cache;
-import org.springframework.stereotype.Component;
 
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.MeterBinder;
@@ -18,11 +13,6 @@ import io.micrometer.core.instrument.binder.MeterBinder;
  * @author Katia Aresti, karesti@redtat.com
  * @since 2.1
  */
-@Component
-@Qualifier(InfinispanCacheMeterBinderProvider.NAME)
-@ConditionalOnMissingBean
-@ConditionalOnClass(name = "org.springframework.boot.actuate.metrics.cache.CacheMeterBinderProvider")
-@ConditionalOnProperty(value = "infinispan.embedded.enabled", havingValue = "true", matchIfMissing = true)
 public class InfinispanCacheMeterBinderProvider implements CacheMeterBinderProvider<Cache> {
 
    public static final String NAME = "infinispanCacheMeterBinderProvider";

--- a/infinispan-spring-boot-starter-embedded/src/main/java/org/infinispan/spring/starter/embedded/actuator/InfinispanCacheMeterBinderProvider.java
+++ b/infinispan-spring-boot-starter-embedded/src/main/java/org/infinispan/spring/starter/embedded/actuator/InfinispanCacheMeterBinderProvider.java
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.binder.cache.JCacheMetrics;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.metrics.cache.CacheMeterBinderProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cache.Cache;
 import org.springframework.stereotype.Component;
@@ -19,6 +20,7 @@ import io.micrometer.core.instrument.binder.MeterBinder;
  */
 @Component
 @Qualifier(InfinispanCacheMeterBinderProvider.NAME)
+@ConditionalOnMissingBean
 @ConditionalOnClass(name = "org.springframework.boot.actuate.metrics.cache.CacheMeterBinderProvider")
 @ConditionalOnProperty(value = "infinispan.embedded.enabled", havingValue = "true", matchIfMissing = true)
 public class InfinispanCacheMeterBinderProvider implements CacheMeterBinderProvider<Cache> {

--- a/infinispan-spring-boot-starter-embedded/src/main/java/org/infinispan/spring/starter/embedded/actuator/InfinispanCacheMeterBinderProviderAutoConfiguration.java
+++ b/infinispan-spring-boot-starter-embedded/src/main/java/org/infinispan/spring/starter/embedded/actuator/InfinispanCacheMeterBinderProviderAutoConfiguration.java
@@ -1,0 +1,21 @@
+package org.infinispan.spring.starter.embedded.actuator;
+
+import org.springframework.boot.actuate.metrics.cache.CacheMeterBinderProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.Cache;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnClass(name = "org.springframework.boot.actuate.metrics.cache.CacheMeterBinderProvider")
+@ConditionalOnProperty(value = "infinispan.embedded.enabled", havingValue = "true", matchIfMissing = true)
+public class InfinispanCacheMeterBinderProviderAutoConfiguration {
+
+    @Bean(InfinispanCacheMeterBinderProvider.NAME)
+    @ConditionalOnMissingBean
+    CacheMeterBinderProvider<Cache> infinispanCacheMeterBinderProvider() {
+        return new InfinispanCacheMeterBinderProvider();
+    }
+}

--- a/infinispan-spring-boot-starter-embedded/src/main/resources/META-INF/spring.factories
+++ b/infinispan-spring-boot-starter-embedded/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.infinispan.spring.starter.embedded.InfinispanEmbeddedAutoConfiguration,\
-org.infinispan.spring.starter.embedded.InfinispanEmbeddedCacheManagerAutoConfiguration
+org.infinispan.spring.starter.embedded.InfinispanEmbeddedCacheManagerAutoConfiguration,\
+org.infinispan.spring.starter.embedded.actuator.InfinispanCacheMeterBinderProviderAutoConfiguration
 

--- a/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/InfinispanEmbeddedEnableTest.java
+++ b/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/InfinispanEmbeddedEnableTest.java
@@ -6,6 +6,7 @@ import static org.infinispan.spring.starter.embedded.InfinispanEmbeddedAutoConfi
 import org.infinispan.spring.starter.embedded.InfinispanEmbeddedAutoConfiguration;
 import org.infinispan.spring.starter.embedded.InfinispanEmbeddedCacheManagerAutoConfiguration;
 import org.infinispan.spring.starter.embedded.actuator.InfinispanCacheMeterBinderProvider;
+import org.infinispan.spring.starter.embedded.actuator.InfinispanCacheMeterBinderProviderAutoConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +15,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest(
       classes = {
             InfinispanEmbeddedAutoConfiguration.class,
-            InfinispanEmbeddedCacheManagerAutoConfiguration.class
+            InfinispanEmbeddedCacheManagerAutoConfiguration.class,
+            InfinispanCacheMeterBinderProviderAutoConfiguration.class
       },
       properties = {
             "spring.main.banner-mode=off",
@@ -31,5 +33,7 @@ public class InfinispanEmbeddedEnableTest {
    public void testDefaultClient() {
       assertThat(beanFactory.containsBeanDefinition(DEFAULT_CACHE_MANAGER_QUALIFIER)).isTrue();
       assertThat(beanFactory.containsBeanDefinition(InfinispanCacheMeterBinderProvider.NAME)).isTrue();
+       assertThat(beanFactory.getBean(InfinispanCacheMeterBinderProvider.NAME))
+               .isInstanceOf(InfinispanCacheMeterBinderProvider.class);
    }
 }

--- a/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/actuator/CustomCacheMeterBinderProviderConfiguration.java
+++ b/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/actuator/CustomCacheMeterBinderProviderConfiguration.java
@@ -1,0 +1,37 @@
+package test.org.infinispan.spring.starter.embedded.actuator;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import org.infinispan.spring.starter.embedded.actuator.InfinispanCacheMeterBinderProvider;
+import org.infinispan.spring.starter.embedded.actuator.InfinispanCacheMeterBinderProviderAutoConfiguration;
+import org.springframework.boot.actuate.metrics.cache.CacheMeterBinderProvider;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.cache.Cache;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+@Configuration
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@AutoConfigureBefore(InfinispanCacheMeterBinderProviderAutoConfiguration.class)
+public class CustomCacheMeterBinderProviderConfiguration {
+
+
+    @Bean(InfinispanCacheMeterBinderProvider.NAME)
+    CacheMeterBinderProvider<Cache> customInfinispanCacheMeterBinderProvider() {
+        return new CustomMeterBinder();
+    }
+
+    public static final class CustomMeterBinder implements CacheMeterBinderProvider<Cache> {
+
+        @Override
+        public MeterBinder getMeterBinder(Cache cache, Iterable<Tag> tags) {
+            return registry -> {
+                //do nothing
+            };
+        }
+    }
+
+
+}

--- a/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/actuator/InfinispanCustomCacheMeterBinderTest.java
+++ b/infinispan-spring-boot-starter-embedded/src/test/java/test/org/infinispan/spring/starter/embedded/actuator/InfinispanCustomCacheMeterBinderTest.java
@@ -1,0 +1,40 @@
+package test.org.infinispan.spring.starter.embedded.actuator;
+
+import org.infinispan.spring.starter.embedded.InfinispanEmbeddedAutoConfiguration;
+import org.infinispan.spring.starter.embedded.InfinispanEmbeddedCacheManagerAutoConfiguration;
+import org.infinispan.spring.starter.embedded.actuator.InfinispanCacheMeterBinderProvider;
+import org.infinispan.spring.starter.embedded.actuator.InfinispanCacheMeterBinderProviderAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.spring.starter.embedded.InfinispanEmbeddedAutoConfiguration.DEFAULT_CACHE_MANAGER_QUALIFIER;
+
+@SpringBootTest(
+        classes = {
+                InfinispanEmbeddedAutoConfiguration.class,
+                InfinispanEmbeddedCacheManagerAutoConfiguration.class,
+                InfinispanCacheMeterBinderProviderAutoConfiguration.class,
+                CustomCacheMeterBinderProviderConfiguration.class
+        },
+        properties = {
+                "spring.main.banner-mode=off",
+                "infinispan.embedded.enabled=true",
+                "infinispan.embedded.caching.enabled=true"
+        }
+)
+public class InfinispanCustomCacheMeterBinderTest {
+
+    @Autowired
+    private ListableBeanFactory beanFactory;
+
+    @Test
+    public void testDefaultClient() {
+        assertThat(beanFactory.containsBeanDefinition(DEFAULT_CACHE_MANAGER_QUALIFIER)).isTrue();
+        assertThat(beanFactory.containsBeanDefinition(InfinispanCacheMeterBinderProvider.NAME)).isTrue();
+        assertThat(beanFactory.getBean(InfinispanCacheMeterBinderProvider.NAME))
+                .isInstanceOf(CustomCacheMeterBinderProviderConfiguration.CustomMeterBinder.class);
+    }
+}


### PR DESCRIPTION
I've encountered problem with default cache meter binder and replicated or distributed embedded cache configuration. Default binder uses stats methods wchich agregate stats from all nodes. This behavior results timouts on /actuator/prometheus endpoints (it took several seconds)

I've prepared PR wchich enables overriding default binding configuration (and showed it in associated test)
I've disabled ```@ComponentScan``` at all. It was used only for binder configuration wchich is easy to create beans by ```@Configuration``` clases. Disabled component scan (wchich was enabled globally) should be also valuable for projects wchich not use that mechanizm at all (especially startup time should decreased)