### PR TITLE
fix broken link to spring-boot

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -14,5 +14,5 @@ $ asciidoctor documentation/asciidoc/titles/spring_boot_starter.asciidoc
 
 Code Examples and Tutorials::
 +
-* link:https://github.com/infinispan/infinispan-simple-tutorials/tree/master/spring-boot[Infinispan Spring Boot Tutorial]
+* link:https://github.com/infinispan/infinispan-simple-tutorials/tree/master/spring-integration/spring-boot[Infinispan Spring Boot Tutorial]
 * link:https://github.com/infinispan-demos/infinispan-near-cache[infinispan-near-cache] showcases Infinispan near caching with Spring Boot.


### PR DESCRIPTION
README.adoc, contains a broken link to "Infinispan Spring Boot Tutorial"